### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub's educational programs",
+        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing GitHub Skills activity to the activities list, as requested in issue #6. The activity teaches practical coding and collaboration skills through GitHub's educational programs.